### PR TITLE
fix: unable to install .deb file on debian systems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
 
 - name: 'Ensure Semaphore installed (Debian-like)'
   ansible.builtin.apt:
-    name: "{{ (semaphore_package_download) | ternary('file:///tmp/semaphore.' + semaphore_pkg_extension, 'semaphore') }}"
+    deb: "{{ (semaphore_package_download) | ternary('file:///tmp/semaphore.' + semaphore_pkg_extension, 'semaphore') }}"
     allow_unauthenticated: true
     state: 'present'
   when: ansible_facts['os_family'] == 'Debian'


### PR DESCRIPTION
The previous version threw an error for me, changing `name` to `deb` fixed it for me. 