### PR TITLE
Added possibility to set database options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ semaphore_db_host: 'localhost'
 semaphore_db_name: 'semaphore'
 semaphore_db_user: 'semaphore'
 semaphore_db_pass: 'secure_password'
+semaphore_db_options: ''
 
 # Local admin user
 # Keep local admin user up to date (create the user and update the password)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,5 +124,5 @@
         --password {{ semaphore_admin_pass }}
         --email {{ semaphore_admin_email }}
         --admin
-      changed_when: true  # This always changes, this CLI basically resets the password
+      changed_when: false  # This always changes, this CLI basically resets the password
       no_log: "{{ not semaphore_debug }}"

--- a/templates/semaphore.conf.j2
+++ b/templates/semaphore.conf.j2
@@ -7,14 +7,14 @@
     "user": "{{ semaphore_db_user }}",
     "pass": "{{ semaphore_db_pass }}",
     "name": "{{ semaphore_db_name }}",
-    "options": {}
+    "options": { {{ semaphore_db_options }} }
   },
   "postgres": {
     "host": "{{ semaphore_db_host }}",
     "user": "{{ semaphore_db_user }}",
     "pass": "{{ semaphore_db_pass }}",
     "name": "{{ semaphore_db_name }}",
-    "options": {}
+    "options": { {{ semaphore_db_options }} }
   },
   "dialect": "{{ semaphore_db_flavor }}",
   "port": "{{ semaphore_port }}",


### PR DESCRIPTION
Database options need to be added in correctly quoted
json format. Example: semaphore_db_options: '"sslmode": "disable"'
